### PR TITLE
create src directory to separate pure functionality from other stuff

### DIFF
--- a/PAT.py
+++ b/PAT.py
@@ -2,7 +2,7 @@ import numpy
 from numpy.random import mtrand
 import pygame
 from configReader import ConfigReader, ConfigContainer
-from logWriter import LogWriter
+from src.io import LogWriter
 from background import *
 from objects import *
 from datetime import date, datetime,time

--- a/src/io.py
+++ b/src/io.py
@@ -19,13 +19,18 @@ class LogWriter:
         self.timeStamp = timeStamp
         self.seed = seed
     
+    def get_path(self) -> Path:
+        """Generate the directory for writing log-related files."""
+        path = Path.cwd() / self.name / self.timeStamp
+        path.mkdir(exist_ok=True)
+        return path
+    
     def writeSeed(self):
         """
         It creates a folder with the name of the current time stamp, and then creates a file
         called seed.txt inside of that folder
         """
-        path = Path.cwd() / self.name / self.timeStamp / "seed.txt"
-        path.mkdir(exist_ok=True)
+        path = self.get_path() / "seed.txt"
         with open(os.fspath(path), "w+") as seedfile:
             seedfile.write(str(self.seed))
 
@@ -38,9 +43,8 @@ class LogWriter:
         Args:
           log: the log object
         """
-        path = Path.cwd() / self.name / self.timeStamp / "data.json"
+        path = self.get_path() / "data.json"
         print(f"log writing to: {os.fspath(path)}")
-        path.mkdir(exist_ok=True)
         with open(os.fspath(path), "w+") as logfile:
             parsed = json.dumps(qDict, indent=5)
             logfile.write(parsed)      
@@ -55,8 +59,7 @@ class LogWriter:
           levelName: The name of the level
           roundNum: the round number of the level. Defaults to 0
         """
-        path = Path.cwd() / self.name / self.timeStamp / "data.json"
-        path.mkdir(exist_ok=True)
+        path = self.get_path() / "data.json"
         with open(os.fspath(path), "a") as logfile:
             parsed = json.dumps(qDict, indent=5)
             logfile.write(parsed)      
@@ -71,8 +74,7 @@ class LogWriter:
         Args:
           qDict: A dictionary of the questions and answers.
         """
-        path = Path.cwd() / self.name / self.timeStamp / "data.json"
-        path.mkdir(exist_ok=True)
+        path = self.get_path() / "data.json"
         with open(os.fspath(path), "w+") as logfile:
             parsed = json.dumps(qDict, indent=5)
             logfile.write(parsed)      

--- a/src/io.py
+++ b/src/io.py
@@ -1,5 +1,5 @@
 import os
-from os import path
+from pathlib import Path
 from datetime import datetime
 import json
 
@@ -18,28 +18,16 @@ class LogWriter:
         self.name = name
         self.timeStamp = timeStamp
         self.seed = seed
-
-    def getPath(self):
-        """
-        It returns the path of the directory where the Python executable is located
-        
-        Returns:
-          The path to the directory containing the Python interpreter.
-        """
-        return os.path.dirname(os.sys.executable)
     
     def writeSeed(self):
         """
         It creates a folder with the name of the current time stamp, and then creates a file
         called seed.txt inside of that folder
         """
-        url = path.join(self.getPath(),f"logs/{self.name}/{self.timeStamp}")
-        if not path.exists(url):
-            os.makedirs(url)
-        
-        newFile = open(url + "/seed.txt","w+")
-
-        newFile.write(str(self.seed))
+        path = Path.cwd() / self.name / self.timeStamp / "seed.txt"
+        path.mkdir(exist_ok=True)
+        with open(os.fspath(path), "w+") as seedfile:
+            seedfile.write(str(self.seed))
 
     #TODO: replace all csv writing to json writing
     #pass log as a list of a list of strings (every sub list is a single tick)
@@ -50,17 +38,12 @@ class LogWriter:
         Args:
           log: the log object
         """
-        url = path.join(self.getPath(),f"logs/{self.name}/{self.timeStamp}")
-        print("log writing to: " + url)
-        if not path.exists(url):
-            os.makedirs(url)
-        url += "/data.json"  
-        #assumed that file will be created via qa write so we can append      
-        logFile = open(url,"w+")
-        
-        parsed = json.dumps(log, indent = 5)
-        logFile.write(parsed)
-        logFile.close()
+        path = Path.cwd() / self.name / self.timeStamp / "data.json"
+        print(f"log writing to: {os.fspath(path)}")
+        path.mkdir(exist_ok=True)
+        with open(os.fspath(path), "w+") as logfile:
+            parsed = json.dumps(qDict, indent=5)
+            logfile.write(parsed)      
 
     # UNUSED
     def writeLevelLog(self,log,levelName,roundNum = 0):
@@ -72,20 +55,11 @@ class LogWriter:
           levelName: The name of the level
           roundNum: the round number of the level. Defaults to 0
         """
-        url = path.join(self.getPath(),f"logs/{self.name}/{self.timeStamp}")
-        
-        if not path.exists(url):
-            os.makedirs(url)
-
-        url += "/data.json"  
-        #assumed that file will be created via qa write so we can append      
-        logFile = open(url,"a")
-        
-        parsed = json.dumps(log, indent = 5)
-
-        logFile.write(parsed)
-
-        logFile.close()
+        path = Path.cwd() / self.name / self.timeStamp / "data.json"
+        path.mkdir(exist_ok=True)
+        with open(os.fspath(path), "a") as logfile:
+            parsed = json.dumps(qDict, indent=5)
+            logfile.write(parsed)      
 
     #questions passed in as a list of strings
     #answers passed in as a list of lists (multiple answers)
@@ -97,18 +71,9 @@ class LogWriter:
         Args:
           qDict: A dictionary of the questions and answers.
         """
-        url = path.join(self.getPath(),f"logs/{self.name}/{self.timeStamp}")
-        
-        if not path.exists(url):
-            os.makedirs(url)
-        
-        url += f"/data.json"
-
-        logFile = open(url,"w+")
-
-        parsed = json.dumps(qDict, indent = 5)
-        logFile.write(parsed)
-
-        logFile.close()
-        
+        path = Path.cwd() / self.name / self.timeStamp / "data.json"
+        path.mkdir(exist_ok=True)
+        with open(os.fspath(path), "w+") as logfile:
+            parsed = json.dumps(qDict, indent=5)
+            logfile.write(parsed)      
     


### PR DESCRIPTION
This moves `LogWriter.py` to `src/io.py`. I'd like to move most of the other "pure code" modules into /src as well over time.